### PR TITLE
Bump golang to v1.22.2 and golangci-lint to 1.57.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.56.2
+          version: v1.57.2

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [ opened, reopened, synchronize ]
 
 jobs:

--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,7 +1,7 @@
 name: Size Label
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ironcore-dev/machine-controller-manager-provider-ironcore
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible


### PR DESCRIPTION
# Proposed Changes

Bump golang to v1.22.2 and golangci-lint to 1.57.2.