### PR TITLE
Remove Gardener dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.22.5
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/coreos/butane v0.21.0
-	github.com/gardener/gardener v1.90.3
 	github.com/gardener/machine-controller-manager v0.53.0
 	github.com/imdario/mergo v0.3.16
 	github.com/ironcore-dev/controller-utils v0.9.3

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/evanphx/json-patch/v5 v5.8.0 h1:lRj6N9Nci7MvzrXuX6HFzU8XjmhPiXPlsKEy1
 github.com/evanphx/json-patch/v5 v5.8.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/gardener/gardener v1.90.3 h1:/CnieoLmpFqfV7DEVIDcqwVZ5Are3xoLTz2dntJBACE=
-github.com/gardener/gardener v1.90.3/go.mod h1:2oopZmb8fQbXXeypRpiY2Nj0kVcobxsMYUn7HOupX84=
 github.com/gardener/machine-controller-manager v0.53.0 h1:g2O0F7nEYZ9LjyPY6Gew8+q0n+rU88deexNq5k8CKks=
 github.com/gardener/machine-controller-manager v0.53.0/go.mod h1:XWXHaTy32TU0qmLjWqOgtw8NncdB0HfFzXhUUrcpr7Y=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=

--- a/pkg/ironcore/suite_test.go
+++ b/pkg/ironcore/suite_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	gardenercorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardenermachinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/ironcore-dev/controller-utils/buildutils"
@@ -88,7 +87,6 @@ var _ = BeforeSuite(func() {
 
 	DeferCleanup(envtestutils.StopWithExtensions, testEnv, testEnvExt)
 	Expect(computev1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(gardenercorev1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(gardenermachinev1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	// Init package-level k8sClient


### PR DESCRIPTION
# Proposed Changes

Remove Gardener dependency as it is not needed for the MCM driver and the suite tests.