### PR TITLE
Fix  ingition secret name length issue

### DIFF
--- a/pkg/ironcore/create_machine.go
+++ b/pkg/ironcore/create_machine.go
@@ -92,7 +92,7 @@ func (d *ironcoreDriver) applyIronCoreMachine(ctx context.Context, req *driver.C
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getIgnitionNameForMachine(req.Machine.Name),
+			Name:      d.getIgnitionNameForMachine(ctx, req.Machine.Name),
 			Namespace: d.IroncoreNamespace,
 		},
 		Data: ignitionData,

--- a/pkg/ironcore/create_machine_test.go
+++ b/pkg/ironcore/create_machine_test.go
@@ -113,7 +113,7 @@ var _ = Describe("CreateMachine", func() {
 				},
 			})),
 			HaveField("Spec.IgnitionRef", &commonv1alpha1.SecretKeySelector{
-				Name: fmt.Sprintf("%s-ignition", machineName),
+				Name: machineName,
 				Key:  defaultIgnitionKey,
 			}),
 		))
@@ -122,7 +122,7 @@ var _ = Describe("CreateMachine", func() {
 		ignition := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
-				Name:      fmt.Sprintf("%s-ignition", machineName),
+				Name:      machineName,
 			},
 		}
 

--- a/pkg/ironcore/delete_machine.go
+++ b/pkg/ironcore/delete_machine.go
@@ -36,7 +36,7 @@ func (d *ironcoreDriver) DeleteMachine(ctx context.Context, req *driver.DeleteMa
 
 	ignitionSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getIgnitionNameForMachine(req.Machine.Name),
+			Name:      d.getIgnitionNameForMachine(ctx, req.Machine.Name),
 			Namespace: d.IroncoreNamespace,
 		},
 	}

--- a/pkg/ironcore/driver.go
+++ b/pkg/ironcore/driver.go
@@ -12,6 +12,8 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
 	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore/pkg/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -51,8 +53,13 @@ func (d *ironcoreDriver) GenerateMachineClassForMigration(_ context.Context, _ *
 	return &driver.GenerateMachineClassForMigrationResponse{}, nil
 }
 
-func getIgnitionNameForMachine(machineName string) string {
-	return fmt.Sprintf("%s-%s", machineName, "ignition")
+func (d *ironcoreDriver) getIgnitionNameForMachine(ctx context.Context, machineName string) string {
+	//for backward compatibility checking if ignition secret was already present with old naming convention
+	ignitionSecretName := fmt.Sprintf("%s-%s", machineName, "ignition")
+	if err := d.IroncoreClient.Get(ctx, client.ObjectKey{Name: ignitionSecretName, Namespace: d.IroncoreNamespace}, &corev1.Secret{}); apierrors.IsNotFound(err) {
+		return machineName
+	}
+	return ignitionSecretName
 }
 
 func getProviderIDForIroncoreMachine(ironcoreMachine *computev1alpha1.Machine) string {


### PR DESCRIPTION
# Proposed Changes

-  Creating the Ignition secret with the same name as the `Machine` name
-  For backward compatibility checking if ignition secret was already present with old naming convention before creating/deleting with new name


Fixes #417 