### PR TITLE
Change ephemeral names for `Volumes` and `NetworkInterfaces`

### DIFF
--- a/pkg/ironcore/create_machine.go
+++ b/pkg/ironcore/create_machine.go
@@ -118,7 +118,7 @@ func (d *ironcoreDriver) applyIronCoreMachine(ctx context.Context, req *driver.C
 			Power: computev1alpha1.PowerOn,
 			NetworkInterfaces: []computev1alpha1.NetworkInterface{
 				{
-					Name: "primary",
+					Name: "nic",
 					NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
 						Ephemeral: &computev1alpha1.EphemeralNetworkInterfaceSource{
 							NetworkInterfaceTemplate: &networkingv1alpha1.NetworkInterfaceTemplateSpec{
@@ -163,7 +163,7 @@ func (d *ironcoreDriver) applyIronCoreMachine(ctx context.Context, req *driver.C
 	} else {
 		ironcoreMachine.Spec.Volumes = []computev1alpha1.Volume{
 			{
-				Name: "primary",
+				Name: "root",
 				VolumeSource: computev1alpha1.VolumeSource{
 					Ephemeral: &computev1alpha1.EphemeralVolumeSource{
 						VolumeTemplate: &storagev1alpha1.VolumeTemplateSpec{

--- a/pkg/ironcore/create_machine_test.go
+++ b/pkg/ironcore/create_machine_test.go
@@ -58,7 +58,7 @@ var _ = Describe("CreateMachine", func() {
 			HaveField("Spec.MachinePoolRef", &corev1.LocalObjectReference{Name: "az1"}),
 			HaveField("Spec.Power", computev1alpha1.PowerOn),
 			HaveField("Spec.NetworkInterfaces", ContainElement(computev1alpha1.NetworkInterface{
-				Name: "primary",
+				Name: "nic",
 				NetworkInterfaceSource: computev1alpha1.NetworkInterfaceSource{
 					Ephemeral: &computev1alpha1.EphemeralNetworkInterfaceSource{
 						NetworkInterfaceTemplate: &networkingv1alpha1.NetworkInterfaceTemplateSpec{
@@ -94,7 +94,7 @@ var _ = Describe("CreateMachine", func() {
 				},
 			})),
 			HaveField("Spec.Volumes", ContainElement(computev1alpha1.Volume{
-				Name:   "primary",
+				Name:   "root",
 				Device: ptr.To("oda"),
 				VolumeSource: computev1alpha1.VolumeSource{
 					Ephemeral: &computev1alpha1.EphemeralVolumeSource{


### PR DESCRIPTION
# Proposed Changes

Change the emphemeral names for `Volume` and `NetworkInterface` resource to `nic` and `root`.
