### PR TITLE
Use topology labels for MachinePool selection with backward compatibility

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.4
+          version: v2.11

--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,8 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 KUSTOMIZE_VERSION ?= v5.5.0
 ADDLICENSE_VERSION ?= v1.1.1
 GEN_CRD_API_REFERENCE_DOCS_VERSION ?= v0.3.0
-GOIMPORTS_VERSION ?= v0.31.0
-GOLANGCI_LINT_VERSION ?= v2.4
+GOIMPORTS_VERSION ?= v0.43.0
+GOLANGCI_LINT_VERSION ?= v2.11
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ironcore-dev/machine-controller-manager-provider-ironcore
 
-go 1.24.1
+go 1.25.0
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible

--- a/pkg/ironcore/create_machine.go
+++ b/pkg/ironcore/create_machine.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/ironcore-dev/ironcore/api/common/v1alpha1"
+	commonv1alpha1 "github.com/ironcore-dev/ironcore/api/common/v1alpha1"
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
 	corev1alpha1 "github.com/ironcore-dev/ironcore/api/core/v1alpha1"
 	ipamv1alpha1 "github.com/ironcore-dev/ironcore/api/ipam/v1alpha1"
@@ -27,6 +27,7 @@ import (
 	apiv1alpha1 "github.com/ironcore-dev/machine-controller-manager-provider-ironcore/pkg/api/v1alpha1"
 	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore/pkg/api/validation"
 	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore/pkg/ignition"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // CreateMachine handles a machine creation request
@@ -98,6 +99,32 @@ func (d *ironcoreDriver) applyIronCoreMachine(ctx context.Context, req *driver.C
 		Data: ignitionData,
 	}
 
+	// Determine pool selection strategy: direct reference (old model) vs topology labels (new model).
+	// In the old model, the zone name was the pool name (1:1 logical pools).
+	// In the new model, multiple pools are grouped by topology labels.
+	zone := req.MachineClass.NodeTemplate.Zone
+	region := req.MachineClass.NodeTemplate.Region
+
+	var machinePoolRef *corev1.LocalObjectReference
+	var machinePoolSelector map[string]string
+
+	pool := &computev1alpha1.MachinePool{}
+	if err := d.IroncoreClient.Get(ctx, client.ObjectKey{Name: zone}, pool); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, status.Error(codes.Internal, fmt.Sprintf("error checking machine pool %q: %s", zone, err.Error()))
+		}
+		// Pool not found by name -> use topology label-based selection
+		machinePoolSelector = map[string]string{
+			string(commonv1alpha1.TopologyLabelZone): zone,
+		}
+		if region != "" {
+			machinePoolSelector[string(commonv1alpha1.TopologyLabelRegion)] = region
+		}
+	} else {
+		// Pool found by name -> old behavior (direct reference)
+		machinePoolRef = &corev1.LocalObjectReference{Name: zone}
+	}
+
 	ironcoreMachine := &computev1alpha1.Machine{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: computev1alpha1.SchemeGroupVersion.String(),
@@ -112,10 +139,9 @@ func (d *ironcoreDriver) applyIronCoreMachine(ctx context.Context, req *driver.C
 			MachineClassRef: corev1.LocalObjectReference{
 				Name: req.MachineClass.NodeTemplate.InstanceType,
 			},
-			MachinePoolRef: &corev1.LocalObjectReference{
-				Name: req.MachineClass.NodeTemplate.Zone,
-			},
-			Power: computev1alpha1.PowerOn,
+			MachinePoolRef:      machinePoolRef,
+			MachinePoolSelector: machinePoolSelector,
+			Power:               computev1alpha1.PowerOn,
 			NetworkInterfaces: []computev1alpha1.NetworkInterface{
 				{
 					Name: "nic",
@@ -151,7 +177,7 @@ func (d *ironcoreDriver) applyIronCoreMachine(ctx context.Context, req *driver.C
 					},
 				},
 			},
-			IgnitionRef: &v1alpha1.SecretKeySelector{
+			IgnitionRef: &commonv1alpha1.SecretKeySelector{
 				Name: ignitionSecret.Name,
 				Key:  ignitionSecretKey,
 			},

--- a/pkg/ironcore/create_machine_test.go
+++ b/pkg/ironcore/create_machine_test.go
@@ -29,7 +29,16 @@ import (
 var _ = Describe("CreateMachine", func() {
 	ns, providerSecret, drv := SetupTest()
 
-	It("should create a machine", func(ctx SpecContext) {
+	It("should create a machine with MachinePoolRef when pool exists by name", func(ctx SpecContext) {
+		By("creating a MachinePool named az1 (old model: zone = pool name)")
+		machinePool := &computev1alpha1.MachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "az1",
+			},
+		}
+		Expect(k8sClient.Create(ctx, machinePool)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, machinePool)
+
 		By("creating machine")
 		machineName := "machine-0"
 		Expect((*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
@@ -41,7 +50,7 @@ var _ = Describe("CreateMachine", func() {
 			NodeName:   machineName,
 		}))
 
-		By("ensuring that the ironcore machine has been created")
+		By("ensuring that the ironcore machine has MachinePoolRef set")
 		machine := &computev1alpha1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns.Name,
@@ -56,6 +65,7 @@ var _ = Describe("CreateMachine", func() {
 			}),
 			HaveField("Spec.MachineClassRef", corev1.LocalObjectReference{Name: "machine-class"}),
 			HaveField("Spec.MachinePoolRef", &corev1.LocalObjectReference{Name: "az1"}),
+			HaveField("Spec.MachinePoolSelector", BeEmpty()),
 			HaveField("Spec.Power", computev1alpha1.PowerOn),
 			HaveField("Spec.NetworkInterfaces", ContainElement(computev1alpha1.NetworkInterface{
 				Name: "nic",
@@ -164,5 +174,36 @@ var _ = Describe("CreateMachine", func() {
 			})
 			g.Expect(err.Error()).To(ContainSubstring("ip is invalid"))
 		}).Should(Succeed())
+	})
+
+	It("should create a machine with MachinePoolSelector when pool does not exist by name", func(ctx SpecContext) {
+		By("creating machine without a MachinePool named az1")
+		machineName := "machine-0"
+		Expect((*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
+			Machine:      newMachine(ns, "machine", -1, nil),
+			MachineClass: newMachineClass(v1alpha1.ProviderName, testing.SampleProviderSpec),
+			Secret:       providerSecret,
+		})).To(Equal(&driver.CreateMachineResponse{
+			ProviderID: fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 0),
+			NodeName:   machineName,
+		}))
+
+		By("ensuring that the ironcore machine has MachinePoolSelector with topology labels")
+		machine := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      machineName,
+			},
+		}
+
+		Eventually(Object(machine)).Should(SatisfyAll(
+			HaveField("Spec.MachineClassRef", corev1.LocalObjectReference{Name: "machine-class"}),
+			HaveField("Spec.MachinePoolRef", BeNil()),
+			HaveField("Spec.MachinePoolSelector", map[string]string{
+				string(commonv1alpha1.TopologyLabelZone):   "az1",
+				string(commonv1alpha1.TopologyLabelRegion): "foo",
+			}),
+			HaveField("Spec.Power", computev1alpha1.PowerOn),
+		))
 	})
 })


### PR DESCRIPTION
Previously, MachinePoolRef was set directly from NodeTemplate.Zone, assuming the zone name equals the pool name (1:1 logical pools).

With the introduction of topology labels in ironcore (ironcore-dev/ironcore#1418), multiple physical pools can now be grouped into zones and regions via topology.ironcore.dev/zone and topology.ironcore.dev/region labels.

This change adds a backward-compatible detection strategy: at machine creation time, a MachinePool with the zone name is looked up. If it exists, MachinePoolRef is set as before. If not, MachinePoolSelector is set with the topology zone and region labels from the NodeTemplate, letting the scheduler pick a matching pool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Machine pool selection now intelligently handles pool availability: uses direct pool references when a named pool exists, and falls back to topology-based selection using zone and region labels when unavailable.

* **Chores**
  * Updated Go toolchain and code quality tool versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->