### PR TITLE
Revert ignition fcos version to v1.3.0

### DIFF
--- a/pkg/ignition/template.yaml
+++ b/pkg/ignition/template.yaml
@@ -1,5 +1,5 @@
 variant: fcos
-version: 1.7.0
+version: 1.3.0
 storage:
   files:
     - path: /etc/hostname

--- a/pkg/ironcore/testing/testing.go
+++ b/pkg/ironcore/testing/testing.go
@@ -38,7 +38,7 @@ var (
 
 	SampleIgnition = map[string]interface{}{
 		"ignition": map[string]interface{}{
-			"version": "3.6.0",
+			"version": "3.2.0",
 		},
 		"passwd": map[string]interface{}{
 			"users": []interface{}{


### PR DESCRIPTION
The current GardenLinux LTS version 2150 does not support ignition version v3.6.0. Reverting back to fcos 1.3.0 which should result in a v3.2.0 ignition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version references in configuration templates and test fixtures to earlier versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->