### PR TITLE
Add volume pool scheduling for root disk volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,9 @@ Following are the basic principles kept in mind while developing the external pl
         ```bash
         kubectl delete -f kubernetes/machine.yaml
         kubectl delete -f kubernetes/machine-deployment.yaml
+
+## Pool Scheduling
+
+When the `MachineClass` `NodeTemplate` specifies a `region` and `zone`, the provider uses topology-aware
+scheduling to determine both the `MachinePool` and (when `rootDisk` is set) the `VolumePool`.
+The `VolumePool` is assumed to be zone-local, so the same topology labels are applied to both.

--- a/pkg/ironcore/create_machine.go
+++ b/pkg/ironcore/create_machine.go
@@ -28,6 +28,7 @@ import (
 	commonv1alpha1 "github.com/ironcore-dev/ironcore/api/common/v1alpha1"
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
 	corev1alpha1 "github.com/ironcore-dev/ironcore/api/core/v1alpha1"
+	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
 	apiv1alpha1 "github.com/ironcore-dev/machine-controller-manager-provider-ironcore/pkg/api/v1alpha1"
 	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore/pkg/api/validation"
 	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore/pkg/ignition"
@@ -78,7 +79,13 @@ func (d *ironcoreDriver) applyIronCoreMachine(ctx context.Context, req *driver.C
 		return nil, err
 	}
 
-	machinePoolRef, machinePoolSelector, err := d.resolveMachinePool(ctx, req.MachineClass.NodeTemplate.Zone, req.MachineClass.NodeTemplate.Region)
+	zone, region := req.MachineClass.NodeTemplate.Zone, req.MachineClass.NodeTemplate.Region
+	machinePoolRef, machinePoolSelector, err := d.resolveMachinePool(ctx, zone, region)
+	if err != nil {
+		return nil, err
+	}
+
+	volumeApplyConfig, err := d.buildVolumeApplyConfig(ctx, providerSpec, zone, region)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +94,7 @@ func (d *ironcoreDriver) applyIronCoreMachine(ctx context.Context, req *driver.C
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to apply ignition secret for machine %s: %v", req.Machine.Name, err))
 	}
 
-	machineApplyConfig := d.buildMachineApplyConfig(ctx, req, providerSpec, ignitionSecretKey, machinePoolRef, machinePoolSelector)
+	machineApplyConfig := d.buildMachineApplyConfig(ctx, req, providerSpec, ignitionSecretKey, machinePoolRef, machinePoolSelector, volumeApplyConfig)
 	if err := d.IroncoreClient.Apply(ctx, machineApplyConfig, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("error applying ironcore machine: %s", err.Error()))
 
@@ -156,9 +163,28 @@ func (d *ironcoreDriver) resolveMachinePool(ctx context.Context, zone string, re
 	return &corev1.LocalObjectReference{Name: zone}, nil, nil
 }
 
-func (d *ironcoreDriver) buildMachineApplyConfig(ctx context.Context, req *driver.CreateMachineRequest, providerSpec *apiv1alpha1.ProviderSpec, ignitionSecretKey string, machinePoolRef *corev1.LocalObjectReference, machinePoolSelector map[string]string) *computev1alpha1ac.MachineApplyConfiguration {
-	volumes := d.buildMachineVolumes(providerSpec)
+func (d *ironcoreDriver) resolveVolumePool(ctx context.Context, zone string, region string) (*corev1.LocalObjectReference, map[string]string, error) {
+	pool := &storagev1alpha1.VolumePool{}
 
+	if err := d.IroncoreClient.Get(ctx, client.ObjectKey{Name: zone}, pool); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, nil, status.Error(codes.Internal, fmt.Sprintf("error checking volume pool %q: %s", zone, err.Error()))
+		}
+
+		volumePoolSelector := map[string]string{
+			string(commonv1alpha1.TopologyLabelZone): zone,
+		}
+		if region != "" {
+			volumePoolSelector[string(commonv1alpha1.TopologyLabelRegion)] = region
+		}
+
+		return nil, volumePoolSelector, nil
+	}
+
+	return &corev1.LocalObjectReference{Name: zone}, nil, nil
+}
+
+func (d *ironcoreDriver) buildMachineApplyConfig(ctx context.Context, req *driver.CreateMachineRequest, providerSpec *apiv1alpha1.ProviderSpec, ignitionSecretKey string, machinePoolRef *corev1.LocalObjectReference, machinePoolSelector map[string]string, volume *computev1alpha1ac.VolumeApplyConfiguration) *computev1alpha1ac.MachineApplyConfiguration {
 	spec := computev1alpha1ac.MachineSpec().
 		WithMachineClassRef(corev1.LocalObjectReference{Name: req.MachineClass.NodeTemplate.InstanceType}).
 		WithPower(computev1alpha1.PowerOn).
@@ -188,7 +214,7 @@ func (d *ironcoreDriver) buildMachineApplyConfig(ctx context.Context, req *drive
 			Name: d.getIgnitionNameForMachine(ctx, req.Machine.Name),
 			Key:  ignitionSecretKey,
 		}).
-		WithVolumes(volumes...)
+		WithVolumes([]*computev1alpha1ac.VolumeApplyConfiguration{volume}...)
 
 	if machinePoolRef != nil {
 		spec.WithMachinePoolRef(corev1.LocalObjectReference{Name: machinePoolRef.Name})
@@ -203,33 +229,42 @@ func (d *ironcoreDriver) buildMachineApplyConfig(ctx context.Context, req *drive
 		WithSpec(spec)
 }
 
-func (d *ironcoreDriver) buildMachineVolumes(providerSpec *apiv1alpha1.ProviderSpec) []*computev1alpha1ac.VolumeApplyConfiguration {
+func (d *ironcoreDriver) buildVolumeApplyConfig(ctx context.Context, providerSpec *apiv1alpha1.ProviderSpec, zone, region string) (*computev1alpha1ac.VolumeApplyConfiguration, error) {
+	vol := computev1alpha1ac.Volume().WithName("root")
 	if providerSpec.RootDisk == nil {
-		return []*computev1alpha1ac.VolumeApplyConfiguration{computev1alpha1ac.Volume().
-			WithName("root").
-			WithLocalDisk(computev1alpha1ac.LocalDiskVolumeSource().
-				WithImage(providerSpec.Image),
-			),
-		}
+		return vol.WithLocalDisk(computev1alpha1ac.LocalDiskVolumeSource().
+			WithImage(providerSpec.Image),
+		), nil
 	}
 
-	return []*computev1alpha1ac.VolumeApplyConfiguration{computev1alpha1ac.Volume().
-		WithName("root").
-		WithEphemeral(computev1alpha1ac.EphemeralVolumeSource().
-			WithVolumeTemplate(storagev1alpha1ac.VolumeTemplateSpec().
-				WithSpec(storagev1alpha1ac.VolumeSpec().
-					WithVolumeClassRef(corev1.LocalObjectReference{Name: providerSpec.RootDisk.VolumeClassName}).
-					WithResources(corev1alpha1.ResourceList{corev1alpha1.ResourceStorage: providerSpec.RootDisk.Size}).
-					WithImage(providerSpec.Image).
-					WithDataSource(storagev1alpha1ac.VolumeDataSource().
-						WithOSImage(storagev1alpha1ac.OSDataSource().
-							WithImage(providerSpec.Image),
-						),
-					),
-				),
+	spec := storagev1alpha1ac.VolumeSpec().
+		WithVolumeClassRef(corev1.LocalObjectReference{Name: providerSpec.RootDisk.VolumeClassName}).
+		WithResources(corev1alpha1.ResourceList{corev1alpha1.ResourceStorage: providerSpec.RootDisk.Size}).
+		WithImage(providerSpec.Image).
+		WithDataSource(storagev1alpha1ac.VolumeDataSource().
+			WithOSImage(storagev1alpha1ac.OSDataSource().
+				WithImage(providerSpec.Image),
 			),
-		),
+		)
+
+	volumePoolRef, volumePoolSelector, err := d.resolveVolumePool(ctx, zone, region)
+	if err != nil {
+		return nil, err
 	}
+
+	if volumePoolRef != nil {
+		spec.WithVolumePoolRef(corev1.LocalObjectReference{Name: volumePoolRef.Name})
+	}
+
+	if volumePoolSelector != nil {
+		spec.WithVolumePoolSelector(volumePoolSelector)
+	}
+
+	return vol.WithEphemeral(computev1alpha1ac.EphemeralVolumeSource().
+		WithVolumeTemplate(storagev1alpha1ac.VolumeTemplateSpec().
+			WithSpec(spec),
+		),
+	), nil
 }
 
 // getIgnitionKeyOrDefault checks if key is empty otherwise return default ingintion key

--- a/pkg/ironcore/create_machine.go
+++ b/pkg/ironcore/create_machine.go
@@ -142,46 +142,31 @@ func (d *ironcoreDriver) buildIgnitionSecretApplyConfig(ctx context.Context, req
 	return secret, ignitionSecretKey, nil
 }
 
-func (d *ironcoreDriver) resolveMachinePool(ctx context.Context, zone string, region string) (*corev1.LocalObjectReference, map[string]string, error) {
-	pool := &computev1alpha1.MachinePool{}
-
-	if err := d.IroncoreClient.Get(ctx, client.ObjectKey{Name: zone}, pool); err != nil {
+func (d *ironcoreDriver) resolvePool(ctx context.Context, obj client.Object, poolKind, zone, region string) (*corev1.LocalObjectReference, map[string]string, error) {
+	if err := d.IroncoreClient.Get(ctx, client.ObjectKey{Name: zone}, obj); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return nil, nil, status.Error(codes.Internal, fmt.Sprintf("error checking machine pool %q: %s", zone, err.Error()))
+			return nil, nil, status.Error(codes.Internal, fmt.Sprintf("error checking %s %q: %s", poolKind, zone, err.Error()))
 		}
 
-		machinePoolSelector := map[string]string{
+		selector := map[string]string{
 			string(commonv1alpha1.TopologyLabelZone): zone,
 		}
 		if region != "" {
-			machinePoolSelector[string(commonv1alpha1.TopologyLabelRegion)] = region
+			selector[string(commonv1alpha1.TopologyLabelRegion)] = region
 		}
 
-		return nil, machinePoolSelector, nil
+		return nil, selector, nil
 	}
 
 	return &corev1.LocalObjectReference{Name: zone}, nil, nil
 }
 
-func (d *ironcoreDriver) resolveVolumePool(ctx context.Context, zone string, region string) (*corev1.LocalObjectReference, map[string]string, error) {
-	pool := &storagev1alpha1.VolumePool{}
+func (d *ironcoreDriver) resolveMachinePool(ctx context.Context, zone, region string) (*corev1.LocalObjectReference, map[string]string, error) {
+	return d.resolvePool(ctx, &computev1alpha1.MachinePool{}, "machine pool", zone, region)
+}
 
-	if err := d.IroncoreClient.Get(ctx, client.ObjectKey{Name: zone}, pool); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return nil, nil, status.Error(codes.Internal, fmt.Sprintf("error checking volume pool %q: %s", zone, err.Error()))
-		}
-
-		volumePoolSelector := map[string]string{
-			string(commonv1alpha1.TopologyLabelZone): zone,
-		}
-		if region != "" {
-			volumePoolSelector[string(commonv1alpha1.TopologyLabelRegion)] = region
-		}
-
-		return nil, volumePoolSelector, nil
-	}
-
-	return &corev1.LocalObjectReference{Name: zone}, nil, nil
+func (d *ironcoreDriver) resolveVolumePool(ctx context.Context, zone, region string) (*corev1.LocalObjectReference, map[string]string, error) {
+	return d.resolvePool(ctx, &storagev1alpha1.VolumePool{}, "volume pool", zone, region)
 }
 
 func (d *ironcoreDriver) buildMachineApplyConfig(ctx context.Context, req *driver.CreateMachineRequest, providerSpec *apiv1alpha1.ProviderSpec, ignitionSecretKey string, machinePoolRef *corev1.LocalObjectReference, machinePoolSelector map[string]string, volume *computev1alpha1ac.VolumeApplyConfiguration) *computev1alpha1ac.MachineApplyConfiguration {

--- a/pkg/ironcore/create_machine_test.go
+++ b/pkg/ironcore/create_machine_test.go
@@ -39,6 +39,15 @@ var _ = Describe("CreateMachine", func() {
 		Expect(k8sClient.Create(ctx, machinePool)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, machinePool)
 
+		By("creating a VolumePool named az1")
+		volumePool := &storagev1alpha1.VolumePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "az1",
+			},
+		}
+		Expect(k8sClient.Create(ctx, volumePool)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, volumePool)
+
 		By("creating machine")
 		machineName := "machine-0"
 		Expect((*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
@@ -112,6 +121,9 @@ var _ = Describe("CreateMachine", func() {
 							Spec: storagev1alpha1.VolumeSpec{
 								VolumeClassRef: &corev1.LocalObjectReference{
 									Name: "foo",
+								},
+								VolumePoolRef: &corev1.LocalObjectReference{
+									Name: "az1",
 								},
 								Resources: corev1alpha1.ResourceList{
 									corev1alpha1.ResourceStorage: resource.MustParse("10Gi"),
@@ -204,6 +216,70 @@ var _ = Describe("CreateMachine", func() {
 				string(commonv1alpha1.TopologyLabelRegion): "foo",
 			}),
 			HaveField("Spec.Power", computev1alpha1.PowerOn),
+			HaveField("Spec.Volumes", ContainElement(computev1alpha1.Volume{
+				Name:   "root",
+				Device: ptr.To("oda"),
+				VolumeSource: computev1alpha1.VolumeSource{
+					Ephemeral: &computev1alpha1.EphemeralVolumeSource{
+						VolumeTemplate: &storagev1alpha1.VolumeTemplateSpec{
+							Spec: storagev1alpha1.VolumeSpec{
+								VolumeClassRef: &corev1.LocalObjectReference{
+									Name: "foo",
+								},
+								VolumePoolSelector: map[string]string{
+									string(commonv1alpha1.TopologyLabelZone):   "az1",
+									string(commonv1alpha1.TopologyLabelRegion): "foo",
+								},
+								Resources: corev1alpha1.ResourceList{
+									corev1alpha1.ResourceStorage: resource.MustParse("10Gi"),
+								},
+								Image: "my-image",
+								DataSource: storagev1alpha1.VolumeDataSource{
+									OSImage: &storagev1alpha1.OSDataSource{
+										Image: "my-image",
+									},
+								},
+							},
+						},
+					},
+				},
+			})),
 		))
+	})
+
+	It("should create a machine with a local disk when rootDisk is not set", func(ctx SpecContext) {
+		By("creating machine with a provider spec without rootDisk")
+		providerSpecWithoutRootDisk := testing.Copy(testing.SampleProviderSpec)
+		delete(providerSpecWithoutRootDisk, "rootDisk")
+
+		machineName := "machine-0"
+		Expect((*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
+			Machine:      newMachine(ns, "machine", -1, nil),
+			MachineClass: newMachineClass(v1alpha1.ProviderName, providerSpecWithoutRootDisk),
+			Secret:       providerSecret,
+		})).To(Equal(&driver.CreateMachineResponse{
+			ProviderID: fmt.Sprintf("%s://%s/machine-%d", v1alpha1.ProviderName, ns.Name, 0),
+			NodeName:   machineName,
+		}))
+
+		By("ensuring that the ironcore machine has a local disk volume")
+		machine := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      machineName,
+			},
+		}
+
+		Eventually(Object(machine)).Should(
+			HaveField("Spec.Volumes", ContainElement(computev1alpha1.Volume{
+				Name:   "root",
+				Device: ptr.To("oda"),
+				VolumeSource: computev1alpha1.VolumeSource{
+					LocalDisk: &computev1alpha1.LocalDiskVolumeSource{
+						Image: "my-image",
+					},
+				},
+			})),
+		)
 	})
 })

--- a/pkg/ironcore/suite_test.go
+++ b/pkg/ironcore/suite_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ironcore-dev/controller-utils/modutils"
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
 	corev1alpha1 "github.com/ironcore-dev/ironcore/api/core/v1alpha1"
+	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
 	envtestutils "github.com/ironcore-dev/ironcore/utils/envtest"
 	"github.com/ironcore-dev/ironcore/utils/envtest/apiserver"
 	"github.com/ironcore-dev/machine-controller-manager-provider-ironcore/pkg/api/v1alpha1"
@@ -97,6 +98,7 @@ var _ = BeforeSuite(func() {
 
 	DeferCleanup(envtestutils.StopWithExtensions, testEnv, testEnvExt)
 	Expect(computev1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(storagev1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(gardenermachinev1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	// Init package-level k8sClient


### PR DESCRIPTION
# Proposed Changes

Resolve volume pool by zone/region for ephemeral volumes to ensure they
are scheduled to the same zone/region as the machine they will be
attached to.

Fixes #545


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Machine creation now uses location-aware pool selection, improving placement for compute and storage resources.
  * Root volumes can now be created automatically from either a local disk or an ephemeral volume template, depending on the machine spec.

* **Bug Fixes**
  * Volume placement now follows zone/region topology when a matching pool is unavailable.
  * Test coverage was expanded to validate the new volume selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->