### PR TITLE
Remove `paths-ignore` filters from required workflows

### DIFF
--- a/.github/workflows/check-codegen.yml
+++ b/.github/workflows/check-codegen.yml
@@ -2,9 +2,6 @@ name: Check Codegen
 
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
 
 jobs:
   check-codegen:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,6 @@ name: Lint Golang Codebase
 
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,6 @@ name: Pull Request Code test
 on:
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
 
 jobs:
   checks:


### PR DESCRIPTION
# Proposed Changes

- Remove path filters from required workflows. The filters prevent PRs from
  merging if they do not match the filter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated code generation checks, linting, and tests now run for every pull request, including those containing only documentation or Markdown changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->